### PR TITLE
Add SDV samples repo to stats

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -78,6 +78,7 @@ jobs:
           - "cicsdev/cics-eventprocessing-java"
           - "cicsdev/base64"
           - "cicsdev/cics-banking-sample-application-cbsa"
+          - "cicsdev/cics-security-sdv-samples"
       # Do not cancel&fail all remaining jobs upon first job failure.
       fail-fast: false
       # Help avoid commit conflicts. Note(JP): this should not be


### PR DESCRIPTION
This samples repo will soon have a bunch of ansible scripts & a GH App acting as examples for customers (& CiP) to follow to implement a pipeline that runs a Security Definition Validation (SDV) process. It will also have a React site deployed to GH Pages providing documentation, and a bunch of workflows.

I'm assuming this is the only change required to add the repo to the stats? Apologies if not (any repo setting changes required?)